### PR TITLE
Version 1.2.1 should also be updated on shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 ---
 name: sodium
-version: 1.2.0
+version: 1.2.1
 authors:
 - Andrew Hamon <andrew@hamon.cc>
 - Didactic Drunk <1479616+didactic-drunk@users.noreply.github.com>


### PR DESCRIPTION
Otherwise the following warning is produced by `shards`
`Shard "sodium" version (1.2.0) doesn't match tag version (1.2.1)`